### PR TITLE
列表过多组件面板高度不够 改成6刚刚好

### DIFF
--- a/Assets/LoxodonFramework/Editor/Views/VariableArrayDrawer.cs
+++ b/Assets/LoxodonFramework/Editor/Views/VariableArrayDrawer.cs
@@ -33,7 +33,7 @@ namespace Loxodon.Framework.Editors
     public class VariableArrayDrawer : PropertyDrawer
     {
         private const float HORIZONTAL_GAP = 5;
-        private const float VERTICAL_GAP = 5;
+        private const float VERTICAL_GAP = 6;
 
         private ReorderableList list;
 


### PR DESCRIPTION
最近发现UI引用的列表很多会导致最下面的+-号看不到