### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![release](https://img.shields.io/github/v/tag/vovgou/loxodon-framework?label=release)](https://github.com/vovgou/loxodon-framework/releases)
 [![openupm](https://img.shields.io/npm/v/com.vovgou.loxodon-framework?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.vovgou.loxodon-framework/)
 [![npm](https://img.shields.io/npm/v/com.vovgou.loxodon-framework)](https://www.npmjs.com/package/com.vovgou.loxodon-framework)
+[![gitcgr](https://gitcgr.com/badge/vovgou/loxodon-framework.svg)](https://gitcgr.com/vovgou/loxodon-framework)
 
 [(中文版)](README_CN.md)
 


### PR DESCRIPTION
Someone visualized your repository on [gitcgr.com](https://gitcgr.com/vovgou/loxodon-framework)! This badge lets visitors explore your codebase as an interactive graph.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/vovgou/loxodon-framework.svg)](https://gitcgr.com/vovgou/loxodon-framework)

Clicking the badge takes users to an interactive visualization of your code structure — functions, classes, modules, and their relationships.